### PR TITLE
Add Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,6 @@ authenticate or enter a match.
 ### Docker in the Cloud VM
 
 Docker is installed with `fuse-overlayfs` storage driver and `iptables-legacy` for
-compatibility in the nested container environment. Start the daemon with
-`sudo dockerd &>/tmp/dockerd.log &` if it's not already running. After starting,
-run `sudo chmod 666 /var/run/docker.sock` for non-root access.
+compatibility in the nested container environment. The `ubuntu` user is in the `docker`
+group for non-root access. Start the daemon with `sudo dockerd &>/tmp/dockerd.log &`
+if it's not already running.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,3 +253,54 @@ pre-built artifact from its GitHub Actions CI for the target OS. See `DEVELOPMEN
 
 `lib/lurker.lua` is called on every `love.update()`. Saving any `.lua` file will
 automatically reload it in the running game — no restart required during development.
+
+---
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+Love2D v12 nightly is installed at `/opt/love2d/` with its binary at `/opt/love2d/bin/love`
+(symlinked to `/usr/local/bin/love`). The shared libraries live in `/opt/love2d/lib/` and
+`LD_LIBRARY_PATH` is configured in `~/.bashrc` to include that path.
+
+The `lua-https` native module (`https.so`) must exist in the project root (`/workspace/https.so`)
+for any API/network calls to work. It is built from source
+([love2d/lua-https](https://github.com/love2d/lua-https)) using cmake + g++ against libcurl and
+openssl. If it is missing, rebuild it:
+
+```bash
+cd /tmp && git clone --depth 1 https://github.com/love2d/lua-https.git
+mkdir -p /tmp/lua-https/build && cd /tmp/lua-https/build
+cmake .. -DCMAKE_CXX_COMPILER=g++ -DUSE_CURL_BACKEND=ON -DUSE_OPENSSL_BACKEND=ON
+make -j$(nproc)
+cp src/https.so /workspace/https.so
+```
+
+### Running the game
+
+```bash
+export LD_LIBRARY_PATH=/opt/love2d/lib:$LD_LIBRARY_PATH
+love .
+```
+
+ALSA audio errors in the log are expected (no sound device in the VM) and do not affect
+gameplay. `conf.lua` sets `t.window.displayindex = 2`; this works in the Cloud VM (which
+has a virtual display), but on a single-monitor setup change it to `1`.
+
+### Backend services
+
+The game client requires two external services for full end-to-end testing:
+
+- **World API** (Django REST) at `http://localhost:8000` — auth, users, decks, cards
+- **Nakama** server at `localhost:7350` — real-time multiplayer
+
+Neither service is in this repository. Without them, the game launches to the initial
+server-selection screen and responds to UI interaction, but cannot authenticate or enter
+a match. The `.env` file (copied from `.env.example`) configures these endpoints.
+
+### Linting and testing
+
+- **Lint:** `luacheck .` — see `AGENTS.md` § Linting for details.
+- **Tests:** No project-level test suite exists. Manual testing is done by running
+  `love .` and interacting with the game.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,12 +295,50 @@ The game client requires two external services for full end-to-end testing:
 - **World API** (Django REST) at `http://localhost:8000` — auth, users, decks, cards
 - **Nakama** server at `localhost:7350` — real-time multiplayer
 
-Neither service is in this repository. Without them, the game launches to the initial
-server-selection screen and responds to UI interaction, but cannot authenticate or enter
-a match. The `.env` file (copied from `.env.example`) configures these endpoints.
+The backend is cloned at `/workspace/backend` and runs via Docker Compose. To start all
+backend services:
+
+```bash
+cd /workspace/backend
+docker compose up -d --build
+```
+
+This starts: Postgres (5432), API (8000), Nakama (7349-7351), and SeaweedFS (8333).
+Migrations and `ensure_nakama_card_fdw` run automatically on API container startup
+via `entrypoint.sh`.
+
+**First-time SeaweedFS setup** (only needed once, after the containers are running):
+
+```bash
+# Create S3 credentials
+docker compose exec seaweedfs-master weed shell -master=seaweedfs-master:9333 <<'EOF'
+s3.configure -user=wildleague -access_key=wildleague -secret_key=wildleague-secret -buckets=cards -actions=Read,Write,List,Tagging,Admin -apply
+EOF
+
+# Seed card data + mirror images to S3
+docker compose exec api python manage.py seed_default_cards
+
+# Allow anonymous read access to card images
+docker compose exec seaweedfs-master weed shell -master=seaweedfs-master:9333 <<'EOF'
+s3.configure -user=anonymous -actions=Read:cards,List:cards -apply
+EOF
+```
+
+**Backend tests:** `docker compose exec api python manage.py test`
+
+Without the backend, the game launches to the server-selection screen but cannot
+authenticate or enter a match.
 
 ### Linting and testing
 
-- **Lint:** `luacheck .` — see `AGENTS.md` § Linting for details.
-- **Tests:** No project-level test suite exists. Manual testing is done by running
-  `love .` and interacting with the game.
+- **Lint (game):** `luacheck .` — see `AGENTS.md` § Linting for details.
+- **Tests (game):** No project-level test suite exists. Manual testing via `love .`.
+- **Lint (backend):** No linter configured; follow `.editorconfig`.
+- **Tests (backend):** `docker compose exec api python manage.py test` (in `/workspace/backend`).
+
+### Docker in the Cloud VM
+
+Docker is installed with `fuse-overlayfs` storage driver and `iptables-legacy` for
+compatibility in the nested container environment. Start the daemon with
+`sudo dockerd &>/tmp/dockerd.log &` if it's not already running. After starting,
+run `sudo chmod 666 /var/run/docker.sock` for non-root access.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `## Cursor Cloud specific instructions` section to `AGENTS.md` to enable future Cloud Agents to quickly set up the full development environment (game client + backend).

### Changes

- **`AGENTS.md`**: Added Cloud-specific section documenting:
  - Love2D v12 nightly installation path (`/opt/love2d/`) and `LD_LIBRARY_PATH` configuration
  - `lua-https` build-from-source instructions (cmake + g++ against libcurl/openssl)
  - Backend Docker Compose setup (Postgres, API, Nakama, SeaweedFS)
  - First-time SeaweedFS S3 credential creation and card seeding steps
  - Backend test commands
  - Docker-in-VM setup notes (fuse-overlayfs, iptables-legacy)
  - Expected ALSA audio errors in headless VM environments

### Environment Verification

Both the game client and full backend stack were set up and verified end-to-end:

**Game Client (Love2D):**
- Love2D v12 nightly installed and running
- `luacheck` linting passes: 0 warnings / 0 errors across 50 files
- `lua-https` native module built from source and working

**Backend (Docker Compose):**
- All 7 services running: Postgres, API, Nakama, SeaweedFS (master, volume, filer, S3)
- Migrations and Nakama FDW configured automatically
- Django tests pass: 2/2
- Default cards seeded (Caveman, Dino, Thunder)

**End-to-End:**
- Game client connects to backend via `/.well-known/nodeinfo` validation
- User signup and signin work through the API
- Game transitions from server selection → auth → lobby → deck builder

[Lobby screen after successful login with Welcome toast](https://cursor.com/agents/bc-b3383771-c011-4bf8-90ad-976a95a4474e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flobby_logged_in.webp)
[Deck builder showing seeded card catalog (Caveman, Dino, Thunder)](https://cursor.com/agents/bc-b3383771-c011-4bf8-90ad-976a95a4474e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdeck_builder_with_cards.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3383771-c011-4bf8-90ad-976a95a4474e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3383771-c011-4bf8-90ad-976a95a4474e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

