### PR TITLE
fix: missing bugs from old pr

### DIFF
--- a/src/entities/deck.lua
+++ b/src/entities/deck.lua
@@ -30,6 +30,23 @@ local function clone_array(array)
 	return cloned
 end
 
+local function capture_cards_runtime_state(cards)
+	local states = {}
+	for _, card in ipairs(cards or {}) do
+		if card then
+			states[card] = {
+				is_card_loading = card.is_card_loading == true,
+				current_cooldown = card.current_cooldown,
+				selectable = card.selectable,
+				preview_card = card.preview_card,
+				char_x = card.char_x,
+				char_y = card.char_y
+			}
+		end
+	end
+	return states
+end
+
 function Deck:load(deck_selected)
 	self.deck_selected = {}
 	self.queue_next_cards = {}
@@ -230,6 +247,7 @@ function Deck:capture_hand_state(card)
 		card_selected = self.card_selected,
 		deck_selected = clone_array(self.deck_selected),
 		queue_next_cards = clone_array(self.queue_next_cards),
+		card_runtime_states = capture_cards_runtime_state(self.deck_selected),
 		played_card = card,
 		played_card_loading = card and card.is_card_loading or false,
 		played_card_cooldown = card and card.current_cooldown or nil
@@ -242,6 +260,15 @@ function Deck:restore_hand_state(state)
 	self.deck_selected = clone_array(state.deck_selected)
 	self.queue_next_cards = clone_array(state.queue_next_cards)
 	self.card_selected = state.card_selected
+
+	for card, card_state in pairs(state.card_runtime_states or {}) do
+		card.is_card_loading = card_state.is_card_loading == true
+		card.current_cooldown = card_state.current_cooldown
+		card.selectable = card_state.selectable
+		card.preview_card = card_state.preview_card
+		card.char_x = card_state.char_x
+		card.char_y = card_state.char_y
+	end
 
 	local played_card = state.played_card
 	if played_card then

--- a/src/entities/deck.lua
+++ b/src/entities/deck.lua
@@ -258,6 +258,17 @@ function Deck:restore_hand_state(state)
 	self:define_positions()
 end
 
+function Deck:apply_hand_intent(intent)
+	if not intent or not intent.played_card then return end
+
+	local card = intent.played_card
+	card.is_card_loading = true
+	card:reset_cooldown()
+
+	self.card_selected = nil
+	self.deck_selected = self:rotate_deck(card)
+end
+
 function Deck:mousepressed(x, y, button)
 	-- right click
 	if button ~= 1 then return end

--- a/src/entities/deck.lua
+++ b/src/entities/deck.lua
@@ -22,6 +22,14 @@ local Deck = {
 	card_selected = nil,
 }
 
+local function clone_array(array)
+	local cloned = {}
+	for i, value in ipairs(array or {}) do
+		cloned[i] = value
+	end
+	return cloned
+end
+
 function Deck:load(deck_selected)
 	self.deck_selected = {}
 	self.queue_next_cards = {}
@@ -217,6 +225,39 @@ function Deck:check_cooldown(dt)
 	end
 end
 
+function Deck:capture_hand_state(card)
+	return {
+		card_selected = self.card_selected,
+		deck_selected = clone_array(self.deck_selected),
+		queue_next_cards = clone_array(self.queue_next_cards),
+		played_card = card,
+		played_card_loading = card and card.is_card_loading or false,
+		played_card_cooldown = card and card.current_cooldown or nil
+	}
+end
+
+function Deck:restore_hand_state(state)
+	if not state then return end
+
+	self.deck_selected = clone_array(state.deck_selected)
+	self.queue_next_cards = clone_array(state.queue_next_cards)
+	self.card_selected = state.card_selected
+
+	local played_card = state.played_card
+	if played_card then
+		played_card.is_card_loading = state.played_card_loading == true
+		if state.played_card_cooldown ~= nil then
+			played_card.current_cooldown = state.played_card_cooldown
+		end
+	end
+
+	if #self.queue_next_cards > 0 and self.queue_next_cards[1] then
+		self.queue_next_cards[1].preview_card = true
+	end
+
+	self:define_positions()
+end
+
 function Deck:mousepressed(x, y, button)
 	-- right click
 	if button ~= 1 then return end
@@ -244,6 +285,8 @@ function Deck:mousepressed(x, y, button)
 				-- click on map?
 				if not (x >= card.x and x <= (card.x + cw))
 						and not (y >= card.y and y <= (card.y + ch)) then
+					local hand_state = self:capture_hand_state(card)
+
 					card.char_x = x
 					card.char_y = y
 
@@ -262,6 +305,7 @@ function Deck:mousepressed(x, y, button)
 						x = card.char_x,
 						y = card.char_y
 					}
+					payload_card._hand_state = hand_state
 
 					local Game = require('src.states.game')
 					Game:spawn_card_intent(card, payload_card)

--- a/src/states/game.lua
+++ b/src/states/game.lua
@@ -235,6 +235,9 @@ function Game:handle_opcode_event(opcode, user_id, data)
 			if self.cards[Constants.USER_ID] then
 				self.cards[Constants.USER_ID][pending.card_id] = nil
 			end
+			if pending.hand_state then
+				Deck:restore_hand_state(pending.hand_state)
+			end
 			self.pending_spawns[data.client_intent_id] = nil
 		end
 		return
@@ -397,6 +400,8 @@ end
 
 function Game:spawn_card_intent(card, payload)
 	if not payload or not payload.client_intent_id or not payload.card_id then return end
+	local hand_state = payload._hand_state
+	payload._hand_state = nil
 
 	local predicted = Utils.copy_table(card)
 	predicted.card_id = payload.card_id
@@ -410,7 +415,8 @@ function Game:spawn_card_intent(card, payload)
 
 	self.cards[Constants.USER_ID][payload.card_id] = predicted
 	self.pending_spawns[payload.client_intent_id] = {
-		card_id = payload.card_id
+		card_id = payload.card_id,
+		hand_state = hand_state
 	}
 
 	coroutine.resume(coroutine.create(function()

--- a/src/states/game.lua
+++ b/src/states/game.lua
@@ -122,13 +122,17 @@ function Game:draw()
 	self:draw_player_status()
 
 	love.graphics.setColor(1, 1, 1, 1)
-	for _, card in pairs(self.cards[Constants.USER_ID]) do
-		card:draw()
+	for entity_id, card in pairs(self.cards[Constants.USER_ID]) do
+		if type(entity_id) == 'string' then
+			card:draw()
+		end
 	end
 
 	love.graphics.setColor(1, 1, 1, 1)
-	for _, card in pairs(self.cards[Constants.ENEMY_ID]) do
-		card:draw()
+	for entity_id, card in pairs(self.cards[Constants.ENEMY_ID]) do
+		if type(entity_id) == 'string' then
+			card:draw()
+		end
 	end
 
 	if Deck.card_selected then

--- a/src/states/game.lua
+++ b/src/states/game.lua
@@ -24,6 +24,9 @@ local Game = {
 	timer = Timer:new(),
 	cards = {},
 	pending_spawns = {},
+	hand_intents = {},
+	hand_intent_order = {},
+	hand_baseline_state = nil,
 	last_match_tick = 0,
 	match_winner_id = nil,
 
@@ -45,6 +48,9 @@ function Game:load()
 	self.cards[Constants.USER_ID] = {}
 	self.cards[Constants.ENEMY_ID] = {}
 	self.pending_spawns = {}
+	self.hand_intents = {}
+	self.hand_intent_order = {}
+	self.hand_baseline_state = nil
 	self.last_match_tick = 0
 	self.match_winner_id = nil
 
@@ -209,7 +215,12 @@ function Game:handle_opcode_event(opcode, user_id, data)
 	if opcode == MatchEvents.entity_spawned then
 		if data and data.entity then
 			self:apply_entity_state(data.entity)
-			self.pending_spawns[data.client_intent_id] = nil
+			local intent_id = data.client_intent_id
+			if intent_id and self.hand_intents[intent_id] then
+				self.hand_intents[intent_id].status = 'accepted'
+			end
+			self.pending_spawns[intent_id] = nil
+			self:maybe_finalize_hand_intents()
 		end
 		return
 	end
@@ -231,14 +242,16 @@ function Game:handle_opcode_event(opcode, user_id, data)
 
 	if opcode == MatchEvents.reject_intent then
 		if data and data.client_intent_id and self.pending_spawns[data.client_intent_id] then
+			local intent_id = data.client_intent_id
 			local pending = self.pending_spawns[data.client_intent_id]
 			if self.cards[Constants.USER_ID] then
 				self.cards[Constants.USER_ID][pending.card_id] = nil
 			end
-			if pending.hand_state then
-				Deck:restore_hand_state(pending.hand_state)
-			end
-			self.pending_spawns[data.client_intent_id] = nil
+			self.pending_spawns[intent_id] = nil
+			self.hand_intents[intent_id] = nil
+			self:remove_hand_intent_order(intent_id)
+			self:rebuild_hand_from_intents()
+			self:maybe_finalize_hand_intents()
 		end
 		return
 	end
@@ -402,6 +415,11 @@ function Game:spawn_card_intent(card, payload)
 	if not payload or not payload.client_intent_id or not payload.card_id then return end
 	local hand_state = payload._hand_state
 	payload._hand_state = nil
+	local intent_id = payload.client_intent_id
+
+	if hand_state and not self.hand_baseline_state then
+		self.hand_baseline_state = hand_state
+	end
 
 	local predicted = Utils.copy_table(card)
 	predicted.card_id = payload.card_id
@@ -414,10 +432,16 @@ function Game:spawn_card_intent(card, payload)
 	predicted.scale_x = 1
 
 	self.cards[Constants.USER_ID][payload.card_id] = predicted
-	self.pending_spawns[payload.client_intent_id] = {
+	self.pending_spawns[intent_id] = {
 		card_id = payload.card_id,
 		hand_state = hand_state
 	}
+	self.hand_intents[intent_id] = {
+		id = intent_id,
+		status = 'pending',
+		played_card = hand_state and hand_state.played_card or card
+	}
+	table.insert(self.hand_intent_order, intent_id)
 
 	coroutine.resume(coroutine.create(function()
 		socket.match_data_send(
@@ -428,6 +452,40 @@ function Game:spawn_card_intent(card, payload)
 			nil
 		)
 	end))
+end
+
+function Game:remove_hand_intent_order(intent_id)
+	for i, id in ipairs(self.hand_intent_order) do
+		if id == intent_id then
+			table.remove(self.hand_intent_order, i)
+			return
+		end
+	end
+end
+
+function Game:rebuild_hand_from_intents()
+	if not self.hand_baseline_state then return end
+
+	Deck:restore_hand_state(self.hand_baseline_state)
+
+	for _, intent_id in ipairs(self.hand_intent_order) do
+		local intent = self.hand_intents[intent_id]
+		if intent then
+			Deck:apply_hand_intent(intent)
+		end
+	end
+end
+
+function Game:maybe_finalize_hand_intents()
+	for _, intent in pairs(self.hand_intents) do
+		if intent.status == 'pending' then
+			return
+		end
+	end
+
+	self.hand_intents = {}
+	self.hand_intent_order = {}
+	self.hand_baseline_state = nil
 end
 
 function Game:queue_entity_removal(bucket, entity_id)

--- a/src/states/lobby.lua
+++ b/src/states/lobby.lua
@@ -27,8 +27,15 @@ function Lobby:load()
 		local matched = match.matchmaker_matched or {}
 		local matched_token = matched.token
 		local matched_match_id = matched.match_id
+		local enemy_user_id = self:get_enemy_user_id(matched.users)
+		if not enemy_user_id then
+			self.matchmake_state = 'idle'
+			self.matchmake_ticket = nil
+			Toast:show('error', 'Failed to identify opponent in matchmaker response.', 4)
+			return
+		end
 
-		Constants.ENEMY_ID = self:get_enemy_user_id(matched.users)
+		Constants.ENEMY_ID = enemy_user_id
 
 		coroutine.resume(coroutine.create(function()
 			self.matchmake_state = 'idle'
@@ -124,8 +131,9 @@ function Lobby:get_enemy_user_id(users)
 	end
 
 	for _, user in pairs(users) do
-		if user.presence.user_id ~= Constants.USER_ID then
-			return user.presence.user_id
+		local presence = user and user.presence
+		if presence and presence.user_id and presence.user_id ~= Constants.USER_ID then
+			return presence.user_id
 		end
 	end
 end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes multiplayer hand sync and optimistic play UX; incorrect rollback could desync the local deck, but scope is limited to intent reject/accept handling.
> 
> **Overview**
> Adds **client-side hand rollback** when the server rejects a card spawn. Before playing a card, the deck captures a snapshot (hand order, queue, cooldowns, selection); `Game` tracks pending spawn intents against that baseline and **rebuilds the hand** from remaining accepted intents on `reject_intent`, clearing tracking when all intents resolve on `entity_spawned`.
> 
> Spawn flow now strips `_hand_state` from the network payload while keeping it locally for intent replay via `Deck:apply_hand_intent` / `restore_hand_state`.
> 
> **Drawing** only renders map entities whose table keys are strings (skips non-ID entries in the card buckets). **Lobby** matchmaking validates the opponent `user_id` with safer `presence` checks and shows an error toast instead of proceeding with a missing enemy ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6e3f32e29390c81d14a51a66e8fb47fba2f623c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->